### PR TITLE
Add Crystal support for .cr and .ecr files

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,14 @@
             "groovy": {
               "symbol": "$",
               "stringWrapper": "\""
+            },
+            "crystal": {
+              "symbol": "#",
+              "stringWrapper": "\""
+            },
+            "ecr": {
+              "symbol": "#",
+              "stringWrapper": "\""
             }
           }
         }
@@ -149,6 +157,16 @@
         "command": "auto.addInterpolation",
         "key": "shift+4",
         "when": "editorTextFocus && editorLangId == 'typescriptreact' && vim.mode != 'Normal' && vim.mode != 'Visual' && vim.mode != 'VisualBlock' && vim.mode != 'VisualLine'"
+      },
+      {
+        "command": "auto.addInterpolation",
+        "key": "shift+3",
+        "when": "editorTextFocus && editorLangId == 'crystal' && vim.mode != 'Normal' && vim.mode != 'Visual' && vim.mode != 'VisualBlock' && vim.mode != 'VisualLine'"
+      },
+      {
+        "command": "auto.addInterpolation",
+        "key": "shift+3",
+        "when": "editorTextFocus && editorLangId == 'ecr' && vim.mode != 'Normal' && vim.mode != 'Visual' && vim.mode != 'VisualBlock' && vim.mode != 'VisualLine'"
       }
     ],
     "languages": [
@@ -204,6 +222,25 @@
         ],
         "extensions": [
           ".vue"
+        ]
+      },
+      {
+        "id": "crystal",
+        "aliases": [
+          "Crystal",
+          "crystal"
+        ],
+        "extensions": [
+          ".cr"
+        ]
+      },
+      {
+        "id": "ecr",
+        "aliases": [
+          "Embed Crystal"
+        ],
+        "extensions": [
+          ".ecr"
         ]
       }
     ]


### PR DESCRIPTION
Thanks for this plugin, my `#` is happy again, at least, in ruby.

This PR adds support for [Crystal language](https://crystal-lang.org).

Language definition grabbed from https://github.com/crystal-lang-tools/vscode-crystal-lang/blob/master/package.json#L38-L69 . I'm not sure if the definitions differ how they are resolved. Should only the id and extensions be kept in this PR?

cc: @faustinoaq
